### PR TITLE
Use with-handlers* so that the program is keyboard interruptible

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -284,8 +284,8 @@
       [(list (cons is (struct LINE (_))) docs* ...)
        (make-SLINE is (best (string-length is) docs* alternate?))]
       [(list (cons is (struct GROUP (x))) docs* ...)
-       (with-handlers ([backtrack? (lambda (exn)
-                                     (best col (cons (cons is x) docs*) alternate?))])
+       (with-handlers* ([backtrack? (lambda (exn)
+                                      (best col (cons (cons is x) docs*) alternate?))])
          (best col (cons (cons is (flatten x)) docs*) #t))]
       [(list (cons is (struct TEXT (t))) docs* ...)
        (if (and width alternate? (too-big? t col width))


### PR DESCRIPTION
Rendering a large document with many choices could take a really long time. The use of `with-handlers` makes it not possible for users to interrupt the program. Switching to `with-handler*` to fix the problem.