### PR TITLE
limit backtracking to a line

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -265,6 +265,9 @@
 ;; layout : (or nat #f) * doc -> simple-doc
 (define (layout width doc)
   ;; best : nat * (listof (cons string doc)) * boolean -> simple-doc
+  ;; col is the current column position
+  ;; docs is a list of (pair of indentation string and document)
+  ;; alternate? is whether we are in the flattening mode
   (let best ([col 0] [docs (list (cons "" doc))] [alternate? #f])
     (match docs
       [(list) (make-SEMPTY)]
@@ -282,7 +285,7 @@
       [(list (cons is (struct MARKUP (f x))) docs* ...)
        (make-SPUSH f (best col (cons (cons is x) (cons #f docs*)) alternate?))]
       [(list (cons is (struct LINE (_))) docs* ...)
-       (make-SLINE is (best (string-length is) docs* alternate?))]
+       (make-SLINE is (best (string-length is) docs* #f))]
       [(list (cons is (struct GROUP (x))) docs* ...)
        (with-handlers ([backtrack? (lambda (exn)
                                      (best col (cons (cons is x) docs*) alternate?))])

--- a/tests.rkt
+++ b/tests.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (require rackunit
+         (only-in racket/list make-list)
          "main.rkt")
 
 (define-syntax pprint
@@ -74,3 +75,25 @@ for (int i = 0; i < 10; i++) {
 END
                 ))
 
+(test-case "overflow on subsequent line does not backtrack"
+  (check-equal? (pprint 10 (h-append
+                            (group (h-append (text "a") line (text "b")))
+                            line
+                            (text "aaaaaaaaaaa")))
+                #<<END
+a b
+aaaaaaaaaaa
+END
+                ))
+
+(test-case "no exponential backtracking"
+  (check-equal?
+   (begin
+     (pprint 10 (h-concat
+                 (append (make-list 100
+                                    (group (h-append (text "a")
+                                                     line
+                                                     (text "b"))))
+                         (list line (text "aaaaaaaaaaa")))))
+     'ok)
+   'ok))


### PR DESCRIPTION
After we see a newline, we no longer need to backtrack, since
the context has been reset

Fixes #4